### PR TITLE
fix(deps): update axios to 1.18.0 to resolve 21 security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
             "dependencies": {
                 "@changesets/cli": "^2.29.7",
                 "@types/prompts": "^2.4.9",
+                "axios": "^1.18.0",
                 "cli-progress": "^3.12.0",
                 "commander": "^14.0.1",
                 "prompts": "^2.4.2",
@@ -54,7 +55,7 @@
         },
         "apps/api-harmonization": {
             "name": "@dxp/api-harmonization",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "license": "MIT",
             "dependencies": {
                 "@dxp/blocks.article": "*",
@@ -959,48 +960,9 @@
                 "node": ">=6"
             }
         },
-        "apps/docs": {
-            "name": "@o2s/docs",
-            "version": "1.2.0",
-            "extraneous": true,
-            "dependencies": {
-                "@docusaurus/core": "3.7.0",
-                "@docusaurus/preset-classic": "3.7.0",
-                "@docusaurus/theme-mermaid": "3.7.0",
-                "@easyops-cn/docusaurus-search-local": "^0.49.2",
-                "@mdx-js/react": "^3.1.0",
-                "@vercel/analytics": "^1.5.0",
-                "@vercel/speed-insights": "^1.2.0",
-                "clsx": "^2.1.1",
-                "docusaurus-plugin-image-zoom": "^3.0.1",
-                "framer-motion": "^12.12.1",
-                "prism-react-renderer": "^2.4.1",
-                "react": "^19.1.0",
-                "react-dom": "^19.1.0",
-                "vanilla-cookieconsent": "^3.1.0"
-            },
-            "devDependencies": {
-                "@docusaurus/module-type-aliases": "3.7.0",
-                "@docusaurus/tsconfig": "3.7.0",
-                "@docusaurus/types": "3.7.0",
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "@tailwindcss/postcss": "^4.1.7",
-                "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-                "autoprefixer": "^10.4.21",
-                "postcss": "^8.5.3",
-                "prettier": "^3.5.3",
-                "tailwindcss": "^4.1.7",
-                "typescript": "5.8.3"
-            },
-            "engines": {
-                "node": ">=18.0"
-            }
-        },
         "apps/frontend": {
             "name": "@dxp/frontend",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "dependencies": {
                 "@dxp/api-harmonization": "*",
                 "@dxp/blocks.article": "*",
@@ -8868,15 +8830,6 @@
             "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
             "license": "MIT"
         },
-        "node_modules/@leichtgewicht/ip-codec": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-            "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@lukeed/csprng": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -10190,6 +10143,312 @@
             "license": "MIT",
             "dependencies": {
                 "@noble/hashes": "^1.1.5"
+            }
+        },
+        "node_modules/@parcel/watcher": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+            "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "detect-libc": "^2.0.3",
+                "is-glob": "^4.0.3",
+                "node-addon-api": "^7.0.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.6.0",
+                "@parcel/watcher-darwin-arm64": "2.6.0",
+                "@parcel/watcher-darwin-x64": "2.6.0",
+                "@parcel/watcher-freebsd-x64": "2.6.0",
+                "@parcel/watcher-linux-arm-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm-musl": "2.6.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm64-musl": "2.6.0",
+                "@parcel/watcher-linux-x64-glibc": "2.6.0",
+                "@parcel/watcher-linux-x64-musl": "2.6.0",
+                "@parcel/watcher-win32-arm64": "2.6.0",
+                "@parcel/watcher-win32-x64": "2.6.0"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+            "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+            "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+            "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+            "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+            "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+            "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+            "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+            "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+            "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+            "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+            "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+            "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -12663,306 +12922,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
-            "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
-            "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
-            "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
-            "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
-            "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
-            "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
-            "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
-            "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
-            "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
-            "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
-            "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
-            "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
-            "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
-            "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
-            "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
-            "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
-            "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
-            "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
-            "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
-            "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -14707,18 +14666,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/bonjour": {
-            "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
-            "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/chai": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -14755,19 +14702,6 @@
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
             "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/connect-history-api-fallback": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
-            "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
         },
@@ -14969,18 +14903,6 @@
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
             "dev": true
         },
-        "node_modules/@types/http-proxy": {
-            "version": "1.17.16",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
-            "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/inquirer": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-6.5.0.tgz",
@@ -15124,18 +15046,6 @@
                 "undici-types": "~7.14.0"
             }
         },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.14",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -15201,15 +15111,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@types/semver": {
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -15227,18 +15128,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/serve-index": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
-            "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/express": "*"
-            }
-        },
         "node_modules/@types/serve-static": {
             "version": "1.15.7",
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
@@ -15248,18 +15137,6 @@
                 "@types/http-errors": "*",
                 "@types/node": "*",
                 "@types/send": "*"
-            }
-        },
-        "node_modules/@types/sockjs": {
-            "version": "0.3.36",
-            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
-            "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/stack-utils": {
@@ -16188,34 +16065,6 @@
                 "node": ">=6.5"
             }
         },
-        "node_modules/accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/accepts/node_modules/negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -16552,15 +16401,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/array-ify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -16853,14 +16693,49 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-            "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/axobject-query": {
@@ -17308,15 +17183,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/batch": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-            "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/bcryptjs": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
@@ -17396,85 +17262,6 @@
             "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/body-parser": {
-            "version": "1.20.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.5",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/body-parser/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/body-parser/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "side-channel": "^1.0.6"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/bonjour-service": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "multicast-dns": "^7.2.5"
-            }
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
@@ -19135,18 +18922,6 @@
                 "typedarray-to-buffer": "^3.1.5"
             }
         },
-        "node_modules/connect-history-api-fallback": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
-            "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/consola": {
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -19952,21 +19727,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/default-gateway": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "execa": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/defaults": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -20134,19 +19894,6 @@
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
             "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
         },
-        "node_modules/destroy": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/detect-indent": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -20174,15 +19921,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/detect-node-es": {
             "version": "1.1.0",
@@ -20236,21 +19974,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/dns-packet": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
-            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@leichtgewicht/ip-codec": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/doctrine": {
@@ -21783,118 +21506,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/express/node_modules/content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/express/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/express/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/express/node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "side-channel": "^1.0.6"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/exsolve": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -22026,21 +21637,6 @@
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/faye-websocket": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "websocket-driver": ">=0.5.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/fb-watchman": {
@@ -22194,48 +21790,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/finalhandler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/finalhandler/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/finalhandler/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/find-cache-dir": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -22321,15 +21875,16 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -22481,16 +22036,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -22563,18 +22118,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -23084,15 +22627,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/handle-thing": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/handlebars": {
             "version": "4.7.8",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -23211,9 +22745,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -23285,69 +22820,6 @@
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "dependencies": {
                 "react-is": "^16.7.0"
-            }
-        },
-        "node_modules/hpack.js": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-            "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "obuf": "^1.0.0",
-                "readable-stream": "^2.0.1",
-                "wbuf": "^1.1.0"
-            }
-        },
-        "node_modules/hpack.js/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/hpack.js/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/hpack.js/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/hpack.js/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/html-entities": {
@@ -23579,15 +23051,6 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
-        "node_modules/http-deceiver": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-            "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -23603,32 +23066,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/http-parser-js": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-            "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/http-proxy": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "eventemitter3": "^4.0.0",
-                "follow-redirects": "^1.0.0",
-                "requires-port": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -23641,15 +23078,6 @@
             "engines": {
                 "node": ">= 14"
             }
-        },
-        "node_modules/http-proxy/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/https-browserify": {
             "version": "1.0.0",
@@ -25827,19 +25255,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/launch-editor": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
-            "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "picocolors": "^1.1.1",
-                "shell-quote": "^1.8.3"
-            }
-        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -25905,7 +25320,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25927,7 +25341,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25949,7 +25362,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25971,7 +25383,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25993,7 +25404,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -26015,7 +25425,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -26037,7 +25446,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -26059,7 +25467,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -26081,7 +25488,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -26103,7 +25509,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -26848,18 +26253,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/merge-descriptors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -26933,21 +26326,6 @@
             "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
@@ -27108,22 +26486,6 @@
             },
             "engines": {
                 "node": ">= 10.16.0"
-            }
-        },
-        "node_modules/multicast-dns": {
-            "version": "7.2.5",
-            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
-            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "dns-packet": "^5.2.2",
-                "thunky": "^1.0.2"
-            },
-            "bin": {
-                "multicast-dns": "cli.js"
             }
         },
         "node_modules/mute-stream": {
@@ -27391,6 +26753,13 @@
             "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
             "dev": true
         },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/node-domexception": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -27446,18 +26815,6 @@
             "version": "1.6.6",
             "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
             "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ=="
-        },
-        "node_modules/node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-            "dev": true,
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 6.13.0"
-            }
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -27857,15 +27214,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/obuf": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/ofetch": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
@@ -28125,22 +27473,6 @@
             "dev": true,
             "dependencies": {
                 "aggregate-error": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/retry": "0.12.0",
-                "retry": "^0.13.1"
             },
             "engines": {
                 "node": ">=8"
@@ -29079,7 +28411,8 @@
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
         },
         "node_modules/public-encrypt": {
             "version": "4.0.3",
@@ -29216,24 +28549,6 @@
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/rc": {
@@ -29971,15 +29286,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -30094,18 +29400,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/retry": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -30146,48 +29440,6 @@
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
-            }
-        },
-        "node_modules/rollup": {
-            "version": "4.49.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
-            "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/estree": "1.0.8"
-            },
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.49.0",
-                "@rollup/rollup-android-arm64": "4.49.0",
-                "@rollup/rollup-darwin-arm64": "4.49.0",
-                "@rollup/rollup-darwin-x64": "4.49.0",
-                "@rollup/rollup-freebsd-arm64": "4.49.0",
-                "@rollup/rollup-freebsd-x64": "4.49.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.49.0",
-                "@rollup/rollup-linux-arm64-musl": "4.49.0",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.49.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.49.0",
-                "@rollup/rollup-linux-x64-gnu": "4.49.0",
-                "@rollup/rollup-linux-x64-musl": "4.49.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.49.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.49.0",
-                "@rollup/rollup-win32-x64-msvc": "4.49.0",
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/router": {
@@ -30469,31 +29721,6 @@
             "integrity": "sha512-xvTNwcbeDayXotnV32zLb3duQsP+4XosHpb/F+tu6VzEZFmIjzPdNk6/O+QOOx5XTh08KL2ufdXeCO33p380pQ==",
             "license": "MIT"
         },
-        "node_modules/select-hose": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-            "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/semver": {
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -30504,66 +29731,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/send/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/send/node_modules/debug/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/send/node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/sentence-case": {
@@ -30583,126 +29750,6 @@
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
-            }
-        },
-        "node_modules/serve-index": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-            "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "accepts": "~1.3.4",
-                "batch": "0.6.1",
-                "debug": "2.6.9",
-                "escape-html": "~1.0.3",
-                "http-errors": "~1.6.2",
-                "mime-types": "~2.1.17",
-                "parseurl": "~1.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/serve-index/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/serve-index/node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/serve-index/node_modules/http-errors": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/serve-index/node_modules/inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/serve-index/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/serve-index/node_modules/setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/serve-index/node_modules/statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/set-blocking": {
@@ -31224,32 +30271,6 @@
                 "no-case": "^2.2.0"
             }
         },
-        "node_modules/sockjs": {
-            "version": "0.3.24",
-            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
-            "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "faye-websocket": "^0.11.3",
-                "uuid": "^8.3.2",
-                "websocket-driver": "^0.7.4"
-            }
-        },
-        "node_modules/sockjs/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/socks": {
             "version": "2.8.4",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
@@ -31325,42 +30346,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/spdy": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.0",
-                "handle-thing": "^2.0.0",
-                "http-deceiver": "^1.2.7",
-                "select-hose": "^2.0.0",
-                "spdy-transport": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/spdy-transport": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.0",
-                "detect-node": "^2.0.4",
-                "hpack.js": "^2.1.6",
-                "obuf": "^1.1.2",
-                "readable-stream": "^3.0.6",
-                "wbuf": "^1.7.3"
             }
         },
         "node_modules/split2": {
@@ -32468,15 +31453,6 @@
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
         },
-        "node_modules/thunky": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/timeout-signal": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-2.0.0.tgz",
@@ -32527,60 +31503,6 @@
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
             "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
             "license": "MIT"
-        },
-        "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
         },
         "node_modules/tinygradient": {
             "version": "1.1.5",
@@ -33967,18 +32889,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/uuid": {
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -34029,118 +32939,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/vite": {
-            "version": "6.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-            "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "jiti": ">=1.21.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -34168,18 +32966,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/wbuf": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "minimalistic-assert": "^1.0.0"
             }
         },
         "node_modules/wcwidth": {
@@ -34391,267 +33177,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/webpack-dev-server": {
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/bonjour": "^3.5.9",
-                "@types/connect-history-api-fallback": "^1.3.5",
-                "@types/express": "^4.17.13",
-                "@types/serve-index": "^1.9.1",
-                "@types/serve-static": "^1.13.10",
-                "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.5",
-                "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.0.11",
-                "chokidar": "^3.5.3",
-                "colorette": "^2.0.10",
-                "compression": "^1.7.4",
-                "connect-history-api-fallback": "^2.0.0",
-                "default-gateway": "^6.0.3",
-                "express": "^4.17.3",
-                "graceful-fs": "^4.2.6",
-                "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.0.1",
-                "launch-editor": "^2.6.0",
-                "open": "^8.0.9",
-                "p-retry": "^4.5.0",
-                "rimraf": "^3.0.2",
-                "schema-utils": "^4.0.0",
-                "selfsigned": "^2.1.1",
-                "serve-index": "^1.9.1",
-                "sockjs": "^0.3.24",
-                "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.4",
-                "ws": "^8.13.0"
-            },
-            "bin": {
-                "webpack-dev-server": "bin/webpack-dev-server.js"
-            },
-            "engines": {
-                "node": ">= 12.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "webpack": {
-                    "optional": true
-                },
-                "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/@types/express": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-            "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "*"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.7",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
-            "integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/http-proxy": "^1.17.8",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
-            },
-            "peerDependenciesMeta": {
-                "@types/express": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/webpack-dev-server/node_modules/schema-utils": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
-                "mime-types": "^2.1.31",
-                "range-parser": "^1.2.1",
-                "schema-utils": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 12.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/webpack-hot-middleware": {
             "version": "2.26.1",
             "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.26.1.tgz",
@@ -34745,35 +33270,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "http-parser-js": ">=0.5.1",
-                "safe-buffer": ">=5.1.0",
-                "websocket-extensions": ">=0.1.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/websocket-extensions": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/whatwg-mimetype": {
@@ -35307,27 +33803,6 @@
             },
             "peerDependencies": {
                 "zod": "^3.25.0 || ^4.0.0"
-            }
-        },
-        "packages/auth/mocked": {
-            "name": "@o2s/auth.mocked",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@auth/prisma-adapter": "^2.9.1",
-                "@prisma/client": "^6.8.2",
-                "bcryptjs": "^3.0.2",
-                "dotenv-cli": "^8.0.0",
-                "jsonwebtoken": "^9.0.2",
-                "prisma": "^6.8.2"
-            },
-            "devDependencies": {
-                "@types/jsonwebtoken": "^9.0.9"
-            },
-            "peerDependencies": {
-                "next-auth": "^5.0.0-beta.27",
-                "zod": "^3.25.4"
             }
         },
         "packages/blocks/article": {
@@ -37958,45 +36433,6 @@
                 "node": "*"
             }
         },
-        "packages/blocks/faq2": {
-            "name": "@o2s/blocks.faq",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
         "packages/blocks/feature-section": {
             "name": "@dxp/blocks.feature-section",
             "version": "0.2.0",
@@ -38581,45 +37017,6 @@
                 "node": "*"
             }
         },
-        "packages/blocks/featured-service-list": {
-            "name": "@o2s/blocks.featured-service-list",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
         "packages/blocks/hero-section": {
             "name": "@dxp/blocks.hero-section",
             "version": "0.2.0",
@@ -38912,45 +37309,6 @@
                 "node": "*"
             }
         },
-        "packages/blocks/invoice-list": {
-            "name": "@o2s/blocks.invoice-list",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
         "packages/blocks/media-section": {
             "name": "@dxp/blocks.media-section",
             "version": "0.2.0",
@@ -39241,279 +37599,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "packages/blocks/notification-details": {
-            "name": "@o2s/blocks.notification-details",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/notification-list": {
-            "name": "@o2s/blocks.notification-list",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/order-details": {
-            "name": "@o2s/blocks.order-details",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/order-list": {
-            "name": "@o2s/blocks.order-list",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/orders-summary": {
-            "name": "@o2s/blocks.orders-summary",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/payments-history": {
-            "name": "@o2s/blocks.payments-history",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/payments-summary": {
-            "name": "@o2s/blocks.payments-summary",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
             }
         },
         "packages/blocks/pricing-section": {
@@ -39810,7 +37895,7 @@
         },
         "packages/blocks/quick-links": {
             "name": "@dxp/blocks.quick-links",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "MIT",
             "dependencies": {
                 "@dxp/configs.integrations": "*",
@@ -40100,280 +38185,6 @@
                 "node": "*"
             }
         },
-        "packages/blocks/service-details": {
-            "name": "@o2s/blocks.service-details",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/service-list": {
-            "name": "@o2s/blocks.service-list",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/surveyjs-form": {
-            "name": "@o2s/blocks.surveyjs-form",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/modules.surveyjs": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/ticket-details": {
-            "name": "@o2s/blocks.ticket-details",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/ticket-list": {
-            "name": "@o2s/blocks.ticket-list",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/ticket-recent": {
-            "name": "@o2s/blocks.ticket-recent",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/blocks/user-account": {
-            "name": "@o2s/blocks.user-account",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
         "packages/cli/create-dxp-app": {
             "version": "0.0.8",
             "license": "MIT",
@@ -40606,32 +38417,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "packages/cli/create-o2s-app": {
-            "version": "1.0.4",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@o2s/telemetry": "^1.0.8",
-                "@types/prompts": "^2.4.9",
-                "cli-progress": "^3.12.0",
-                "commander": "^14.0.0",
-                "prompts": "^2.4.2",
-                "simple-git": "^3.27.0",
-                "ts-node": "^10.9.2"
-            },
-            "bin": {
-                "create-o2s-app": "dist/index.js"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "@types/cli-progress": "^3.11.6",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "typescript": "^5.8.3"
             }
         },
         "packages/configs/eslint-config": {
@@ -41228,45 +39013,6 @@
             "version": "1.0.3",
             "license": "MIT"
         },
-        "packages/create-o2s-app": {
-            "version": "1.0.4",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@o2s/telemetry": "^1.0.8",
-                "@types/prompts": "^2.4.9",
-                "cli-progress": "^3.12.0",
-                "commander": "^14.0.0",
-                "prompts": "^2.4.2",
-                "simple-git": "^3.27.0",
-                "ts-node": "^10.9.2"
-            },
-            "bin": {
-                "create-o2s-app": "dist/index.js"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "@types/cli-progress": "^3.11.6",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "typescript": "^5.8.3"
-            }
-        },
-        "packages/eslint-config": {
-            "name": "@dxp/eslint-config",
-            "version": "0.0.0",
-            "extraneous": true,
-            "devDependencies": {
-                "@typescript-eslint/eslint-plugin": "^7.1.0",
-                "@typescript-eslint/parser": "^7.1.0",
-                "eslint-config-prettier": "^9.1.0",
-                "eslint-config-turbo": "^2.0.0",
-                "eslint-plugin-only-warn": "^1.1.0",
-                "typescript": "5.5.4"
-            }
-        },
         "packages/framework": {
             "name": "@dxp/framework",
             "version": "0.3.0",
@@ -41506,66 +39252,9 @@
                 "node": "*"
             }
         },
-        "packages/integrations/algolia": {
-            "name": "@dxp/integrations.algolia",
-            "version": "1.2.0",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/framework": "*",
-                "@o2s/utils.logger": "*",
-                "algoliasearch": "^5.25.0"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "rxjs": "^7"
-            }
-        },
-        "packages/integrations/medusajs": {
-            "name": "@dxp/integrations.medusajs",
-            "version": "1.5.2",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/framework": "*",
-                "@medusajs/js-sdk": "^2.8.2",
-                "@medusajs/types": "^2.8.2",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "rxjs": "^7"
-            }
-        },
         "packages/integrations/mocked": {
             "name": "@dxp/integrations.mocked",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -41851,34 +39540,6 @@
                 "node": "*"
             }
         },
-        "packages/integrations/redis": {
-            "name": "@dxp/integrations.redis",
-            "version": "1.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/framework": "*",
-                "@o2s/utils.logger": "*",
-                "redis": "^5.0.1"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "rxjs": "^7"
-            }
-        },
         "packages/integrations/strapi-cms": {
             "name": "@dxp/integrations.strapi-cms",
             "version": "0.4.0",
@@ -42124,82 +39785,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "packages/modules/surveyjs": {
-            "name": "@o2s/modules.surveyjs",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@dxp/configs.integrations": "*",
-                "@dxp/framework": "*",
-                "@dxp/ui": "*",
-                "@dxp/utils.api-harmonization": "*",
-                "@dxp/utils.frontend": "*",
-                "@o2s/utils.logger": "*"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "dotenv-cli": "^8.0.0",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "@types/react": "^19",
-                "@types/react-dom": "^19",
-                "next": "^15.3.2",
-                "next-intl": "^4.1.0",
-                "react": "^19",
-                "react-dom": "^19",
-                "rxjs": "^7",
-                "tailwindcss": "^4"
-            }
-        },
-        "packages/prettier-config": {
-            "name": "@dxp/prettier-config",
-            "version": "0.0.0",
-            "extraneous": true,
-            "license": "MIT"
-        },
-        "packages/telemetry": {
-            "name": "@o2s/telemetry",
-            "version": "1.0.8",
-            "extraneous": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "boxen": "^6.2.1",
-                "ci-info": "^4.2.0",
-                "configstore": "^6.0.0",
-                "is-docker": "^3.0.0",
-                "ts-node": "^10.9.2",
-                "uuid": "^11.1.0"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "@types/configstore": "^6.0.2",
-                "eslint": "^9.27.0",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            }
-        },
-        "packages/typescript-config": {
-            "name": "@dxp/typescript-config",
-            "version": "0.0.0",
-            "extraneous": true,
-            "license": "MIT"
         },
         "packages/ui": {
             "name": "@dxp/ui",
@@ -43006,46 +40591,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "packages/utils/logger": {
-            "name": "@o2s/utils.logger",
-            "version": "1.1.0",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "axios": "^1.9.0",
-                "jwt-decode": "^4.0.0",
-                "winston": "^3.17.0"
-            },
-            "devDependencies": {
-                "@dxp/eslint-config": "*",
-                "@dxp/prettier-config": "*",
-                "@dxp/typescript-config": "*",
-                "concurrently": "^9.1.2",
-                "eslint": "^9.27.0",
-                "eslint-config-prettier": "^10.1.5",
-                "prettier": "^3.5.3",
-                "tsc-alias": "^1.8.16",
-                "typescript": "^5.8.3"
-            },
-            "peerDependencies": {
-                "@nestjs/axios": "^4",
-                "@nestjs/common": "^11",
-                "@nestjs/config": "^4.0.2",
-                "@nestjs/core": "^11",
-                "rxjs": "^7"
-            }
-        },
-        "packages/utils/models": {
-            "name": "@dxp/utils.api-harmonization",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@dxp/framework": "*",
-                "dayjs": "^1.11.13",
-                "jsonwebtoken": "^9.0.2"
             }
         }
     }


### PR DESCRIPTION
## Summary

Updates `axios` from 1.9.0 to 1.18.0 in `package-lock.json`.

## Cleared advisories

21 OSV advisories for `axios` resolved by this update, including:

| Advisory | CVSS | Description |
|---|---|---|
| GHSA-35jp-ww65-95wh | 8.7 | Prototype pollution via methods |
| GHSA-3g43-6gmg-66jw | 7.0 | Arbitrary request forgery |
| GHSA-p92q-9vqr-4j8v | 8.2 | ReDoS |
| GHSA-43fc-jf86-j433 | 7.5 | XSS |
| GHSA-42h9-826w-cgv3 | 6.3 | DoS via formDataToJSON recursion |
| GHSA-7q8q-rj6j-mhjq | 6.3 | Prototype pollution via nested options |
| GHSA-jqh4-m9w3-8hp9 | 6.3 | ReadableStream bypasses maxBodyLength |

Full list verified via `osv-scanner --lockfile package-lock.json` before and after.

## Scope

- `package-lock.json` only
- No source code changes
- `@nestjs/axios` peer dependency range `^1.3.1` is satisfied
- Semver-minor update (1.9.0 → 1.18.0)

## Remaining advisories

Other non-axios advisories detected by osv-scanner are unaffected by this change.